### PR TITLE
Save dialog

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,11 +89,6 @@ export function activate(context: vscode.ExtensionContext) {
         } catch (error) { console.log("error " + error); }
 
     }, null, context.subscriptions);
-    
-    let statusbarVersion = new StatusbarVersion(context);
-    statusbarVersion.bindEvent();
-
-    context.subscriptions.push(statusbarVersion);
 }
 
 // this method is called when your extension is deactivated
@@ -184,75 +179,3 @@ function isReadOnly(doc: vscode.TextDocument): boolean {
     }
 }
 
-class StatusbarVersion
-{
-    private m_statusbar: vscode.StatusBarItem;
-    private m_context: vscode.ExtensionContext;
-    public constructor(context: vscode.ExtensionContext)
-    {
-        try{
-            this.m_statusbar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-            this.m_context = context;
-        } catch (error)
-        {
-            console.log(error);
-        }
-    }
-
-    public bindEvent()
-    {
-        try{
-            vscode.workspace.onDidOpenTextDocument((event) => {
-                if( event != null )
-                {
-                    this.writeVersionToStatusbar(event);
-                }
-            }, null, this.m_context.subscriptions);
-
-            vscode.workspace.onDidSaveTextDocument((event) => {
-                if( event != null )
-                {
-                    this.writeVersionToStatusbar(event);
-                }
-            }, null, this.m_context.subscriptions);
-
-            vscode.workspace.onDidChangeTextDocument((event) => {
-                if( event != null && event.document )
-                {
-                    this.writeVersionToStatusbar(event.document);
-                }
-            }, null, this.m_context.subscriptions);
-        } catch(error)
-        {
-            console.log(error);
-        }
-    }
-
-    public writeVersionToStatusbar(doc: vscode.TextDocument)
-    {
-        try{
-            let l_retText = "";
-            exec( "cleartool ls -short " + doc.fileName, (error, stdout, stderr) => {
-                if( error )
-                {
-                    l_retText = "view local";
-                }
-                else
-                {
-                    l_retText = stdout.split("@@")[1];
-                    l_retText = l_retText.substring(1).trim();
-                    l_retText = "[" + l_retText.replace(/\\/g, "/") + "]";
-                }
-                this.m_statusbar.text = l_retText;
-                this.m_statusbar.show();
-            });
-        } catch (error){
-            return;
-        }
-    }
-
-    public dispose()
-    {
-        this.m_statusbar.dispose();
-    }
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,7 +128,11 @@ function checkoutAndSaveFile(doc: vscode.TextDocument) {
         console.log(`stdout: ${stdout}`);
         console.log(`stderr: ${stderr}`);
         console.log(`saving file...`);
-        doc.save();
+        // only trigger save if checkout did work
+        // If not and the user canceled this dialog the save event is
+        // retriggered because of that save.
+        if( isReadOnly(doc) === false )
+            doc.save();
     });
 }
 


### PR DESCRIPTION
When canceling the checkout dialog, the dialog reappeared because of the subsequent save() call, no matter the checkout worked or not.