### PR TITLE
Keep file when undo checkout

### DIFF
--- a/src/ccConfiguration.ts
+++ b/src/ccConfiguration.ts
@@ -36,6 +36,7 @@ export class ccConfiguration
 	private m_useClearDlg: ConfigurationProperty<boolean> = new ConfigurationProperty(true);
 	private m_checkoutCommand: ConfigurationProperty<string> = new ConfigurationProperty("-comment ${comment} ${filename}");
 	private m_findCheckoutsCommand: ConfigurationProperty<string> = new ConfigurationProperty("-me -cview -short -avobs");
+	private m_uncoKeepFile: ConfigurationProperty<boolean> = new ConfigurationProperty(true);
 	private m_checkinCommand: ConfigurationProperty<string> = new ConfigurationProperty("-comment ${comment} ${filename}");
 	private m_defaultComment: ConfigurationProperty<string> = new ConfigurationProperty(null);
 	private m_viewPrivateFiles: ConfigurationProperty<string> = new ConfigurationProperty('(hh|cpp|def|c|h|txt)$');
@@ -74,6 +75,10 @@ export class ccConfiguration
 
 	public get FindCheckoutsCommand() : ConfigurationProperty<string> {
 		return this.m_findCheckoutsCommand;
+	}
+
+	public get UncoKeepFile() : ConfigurationProperty<boolean> {
+		return this.m_uncoKeepFile;
 	}
 
 	public get DefaultComment(): ConfigurationProperty<string> {

--- a/src/clearcase.ts
+++ b/src/clearcase.ts
@@ -195,9 +195,17 @@ export class ClearCase {
 
   public undoCheckoutFile(doc: Uri) {
     var path = doc.fsPath;
-    exec("cleartool unco -rm \"" + path + "\"", (error, stdout, stderr) => {
-      this.m_updateEvent.fire(doc);
-    });
+    let useClearDlg = this.configHandler.configuration.UseClearDlg.Value;
+    if (useClearDlg) {
+      exec("cleardlg /uncheckout \"" + path + "\"", (error, stdout, stderr) => {
+        this.m_updateEvent.fire(doc);
+      });
+    } else {
+      let uncoKeepFile = this.configHandler.configuration.UncoKeepFile.Value;
+      exec(`cleartool unco ${uncoKeepFile ? "-keep" : "-rm"} \\"${path}\\"`, (error, stdout, stderr) => {
+        this.m_updateEvent.fire(doc);
+      });
+    }
   }
 
   public createVersionedObject(doc: Uri) {


### PR DESCRIPTION
Add option to keep content of checkedout file if doing an undo.
If cleardlg is activated, use this for undoing the checkout.

Fixes #77