### PR TITLE
Fixed regex for comments in config-spec

### DIFF
--- a/syntaxes/config-spec.tmLanguage.json
+++ b/syntaxes/config-spec.tmLanguage.json
@@ -127,7 +127,7 @@
 			"patterns": [
 				{
 					"name": "comment.line.number-sign.config-spec",
-					"match": "^\\s*#.*$"
+					"match": "#.*$"
 				}
 			]
 		},


### PR DESCRIPTION
* not only match at the beginning of line
* applies to syntax highlighting for config-spec files only