### PR TITLE
runCleartoolCommand: combine onError, onFinished

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,8 @@
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
         "@typescript-eslint/restrict-plus-operands": "error",
         "@typescript-eslint/unbound-method": "error",
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "curly": "error",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",


### PR DESCRIPTION
Instead of firing `onError` for each chunk of data received on stderr, accumulate all chunks from stderr and handle them during the "close" even, similar to `onFinished`.

Since `onError` and `onFinished` are usually handled together, combine them into a single `onFinished` function which apart from the stdout contents will now also return the exit code and stderr contents.

While at it, remove some duplicate logging of stderr contents by handling that only in `runCleartoolCommand`.

Fixes OpenNingia/vscode-clearcase#131