### PR TITLE
Added parsing of environment variables in configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.vsix
 npm-debug.log
 webpack.config.js*
+findmerge*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,7 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "npm: webpack"
+			]
 		},
 		{
 			"name": "Run Extension",
@@ -47,6 +46,9 @@
 			"name": "Extension Tests (webpack)",
 			"type": "extensionHost",
 			"request": "launch",
+			"env": {
+				"WS_ROOT": "${workspaceFolder}"
+			},
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
@@ -54,8 +56,7 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
-			],
-			"preLaunchTask": "npm: pretest"
+			]
 		}
 	]
 }

--- a/src/ccConfiguration.ts
+++ b/src/ccConfiguration.ts
@@ -3,6 +3,32 @@ export class PathMapping {
   wsl = "";
 }
 
+export class Variables {
+  static parse<T>(value: T): T {
+    if (value === null || value === "" || typeof value !== "string") {
+      return value;
+    }
+
+    // get env variable
+    const idx = value.indexOf("env:");
+    let retVal = value as string;
+    if (idx > 0) {
+      const matches = value.matchAll(/\$\{env:(\w+)\}/gi);
+      for (const subgrp of matches) {
+        if (subgrp.length > 0) {
+          if (subgrp[1] in process.env) {
+            const v = process.env[subgrp[1]];
+            if (v !== undefined) {
+              retVal = retVal.replace(subgrp[0], v);
+            }
+          }
+        }
+      }
+    }
+    return retVal as T;
+  }
+}
+
 export class ConfigurationProperty<T> {
   private mChanged: boolean;
 
@@ -16,7 +42,7 @@ export class ConfigurationProperty<T> {
 
   set value(value: T) {
     if (this.mProp !== value) {
-      this.mProp = value;
+      this.mProp = Variables.parse<T>(value);
       this.mChanged = true;
     }
   }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -11,6 +11,10 @@ import { after, before, beforeEach } from "mocha";
 import SuiteOutputChannel from "../mock/SuiteOutputChannel";
 // import * as myExtension from '../../extension';
 
+//const WS_ROOT = process.env["WS_ROOT"] ? process.env["WS_ROOT"] : "";
+const TEST_HOME = process.env["HOME"] ? process.env["HOME"] : "-";
+const TEST_USER = process.env["USER"] ? process.env["USER"] : "-";
+
 suite("Extension Test Suite", () => {
   vscode.window.showInformationMessage("Start all tests.");
   let extensionContext: vscode.ExtensionContext;
@@ -126,6 +130,41 @@ suite("Extension Test Suite", () => {
       outputChannel.getLastLine(),
       `cleartool: Error: Element "${file}" is already checked out to view "myview".\n`
     );
+  });
+
+  test("Extension: Path names with environment variable", async () => {
+    configHandler.configuration.tempDir.value = "${env:HOME}/tmp";
+    assert.strictEqual(`${TEST_HOME}/tmp`, configHandler.configuration.tempDir.value);
+  });
+
+  test("Extension: Path names with multiple environment variables", async () => {
+    configHandler.configuration.tempDir.value = "${env:HOME}/tmp/${env:USER}";
+    assert.strictEqual(`${TEST_HOME}/tmp/${TEST_USER}`, configHandler.configuration.tempDir.value);
+  });
+
+  test("Extension: Path names with invalid variable 1", async () => {
+    configHandler.configuration.tempDir.value = "${HOME}/tmp";
+    assert.strictEqual('${HOME}/tmp', configHandler.configuration.tempDir.value);
+  });
+
+  test("Extension: Path names with invalid variable 2", async () => {
+    configHandler.configuration.tempDir.value = "{HOME}/tmp";
+    assert.strictEqual('{HOME}/tmp', configHandler.configuration.tempDir.value);
+  });
+
+  test("Extension: Path names with invalid variable 3", async () => {
+    configHandler.configuration.tempDir.value = "{env:}/tmp";
+    assert.strictEqual('{env:}/tmp', configHandler.configuration.tempDir.value);
+  });
+
+  test("Extension: Path names with invalid variable 4", async () => {
+    configHandler.configuration.tempDir.value = "${env:}/tmp";
+    assert.strictEqual('${env:}/tmp', configHandler.configuration.tempDir.value);
+  });
+
+  test("Extension: Path names with invalid variable 5", async () => {
+    configHandler.configuration.tempDir.value = "${env:}/tmp/${env:USER}";
+    assert.strictEqual('${env:}/tmp' + `/${TEST_USER}`, configHandler.configuration.tempDir.value);
   });
 
 });


### PR DESCRIPTION
It is now possible to use the ${env:VAR} syntax in the configuration.